### PR TITLE
Add subnet for L7 ILB example

### DIFF
--- a/codelab19v2/labs/L7_ILB/main.tf
+++ b/codelab19v2/labs/L7_ILB/main.tf
@@ -50,6 +50,16 @@ resource "google_compute_subnetwork" "vpc_demo_subnet_l7_ilb" {
   enable_flow_logs         = false
 }
 
+resource "google_compute_subnetwork" "vpc_demo_subnet_l7_ilb_reserved" {
+  provider      = google-beta
+  name          = "${local.prefix}vpc-demo-subnet-l7-ilb-reserved"
+  ip_cidr_range = "10.126.0.0/22"
+  region        = "us-east1"
+  network       = google_compute_network.vpc_demo.self_link
+  purpose       = "INTERNAL_HTTPS_LOAD_BALANCER"
+  role          = "ACTIVE"
+}
+
 # firewall rules
 
 resource "google_compute_firewall" "vpc_demo_allow_internal" {


### PR DESCRIPTION
Supported as of [version 2.15.0 of the Google Terraform Beta provider](https://github.com/terraform-providers/terraform-provider-google-beta/blob/master/CHANGELOG.md#2150-september-17-2019)