### PR TITLE
update network module on the TD lab to work with TF 0.12

### DIFF
--- a/codelab19/labs/Traffic_Director/main.tf
+++ b/codelab19/labs/Traffic_Director/main.tf
@@ -37,7 +37,7 @@ locals {
 
 module "vpc_demo" {
   source  = "terraform-google-modules/network/google"
-  version = "0.6.0"
+  version = "1.2.0"
 
   project_id   = "${var.project_id}"
   network_name = "${local.prefix}vpc-demo"


### PR DESCRIPTION
0.6.0 fails since triggers does not have an assignment.